### PR TITLE
Correct contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yarn test
 
 ## Contributions
 
-See [CONTRIBUTING.md](https://github.com/googleads/ad-speed-insights/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/googleads/ad-speed-insights/blob/master/lighthouse-plugin-ad-speed-insights/CONTRIBUTING.md)
 
 
 


### PR DESCRIPTION
At the moment, the main directory does not have a CONTRIBUTING.md file, which means the link in the primary README was broken. I have corrected this link to go to the Lighthouse plugin contributing guidelines.